### PR TITLE
mention 256x64 support added for capcom

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since not any consumer (especially the Raspberry Pi) can act as an SPI slave thi
 * Stern Whitestar -> 128x32
 * Stern SAM -> 128x32
 * Stern SPIKE 1 -> 128x32
-* Capcom -> 128x32
+* Capcom -> 128x32 & 256x64
 * Gottlieb/Premier -> 128x32
 * Alvin G. & Co -> 128x32
 


### PR DESCRIPTION
Potential 0.6.0 release notes: 

- Added support for 128x32 and 256x64 CAPCOM
- Added support for 128x32 Gottlieb/Premier
- Added support for (to be confirmed) 128x32 Inder/SPinball
- Added loopback mode for PPUC/DMD
- Many performance improvements and code restructures