### PR TITLE
Gottlieb

### DIFF
--- a/src/dmdreader.cpp
+++ b/src/dmdreader.cpp
@@ -856,7 +856,7 @@ bool dmdreader_init(bool return_on_no_detection) {
       source_bitsperpixel = 4;
       target_bitsperpixel = 2;
       source_planesperframe = 6;
-      source_planehistoryperframe = 0;
+      source_planehistoryperframe = 5;
       source_lineoversampling = LINEOVERSAMPLING_NONE;
       source_mergeplanes = MERGEPLANES_ADD;
       break;

--- a/src/dmdreader.cpp
+++ b/src/dmdreader.cpp
@@ -856,7 +856,7 @@ bool dmdreader_init(bool return_on_no_detection) {
       source_bitsperpixel = 4;
       target_bitsperpixel = 2;
       source_planesperframe = 6;
-      source_planehistoryperframe = 5;
+      source_planehistoryperframe = 3;
       source_lineoversampling = LINEOVERSAMPLING_NONE;
       source_mergeplanes = MERGEPLANES_ADD;
       break;


### PR DESCRIPTION
planehistory to 3 to reduce the load on Pi: 
- New frame was sent at a rate of 2.5ms before, now it's 7.5ms. 
- Creates a similar effect compared to a plasma display visible in the Stargate logo