### PR TITLE
Skip sending of the very first buffer as it is always empty

### DIFF
--- a/src/dmdreader.cpp
+++ b/src/dmdreader.cpp
@@ -807,7 +807,7 @@ void dmd_dma_handler() {
     // merge the rows and convert from 4bpp to 2bpp with a LUT
     uint32_t *dst, *src1, *src2;
     dst = framebuf + 64; // start in the middle of 128x32 frame
-    src1 = framebuf + 511; // everything is stored from here onwards
+    src1 = framebuf + offset_x16; // everything is stored from here onwards
     src2 = src1 + source_dwordsperline;
 
     if (dmd_type == DMD_DE_X16_V1) {

--- a/src/dmdreader.cpp
+++ b/src/dmdreader.cpp
@@ -117,6 +117,7 @@ bool detected_1_0_0_0 = false;
 bool locked_in = false;
 bool plane0_shifted = false;
 bool loopback = false;
+bool filled_buffer = false;
 
 // SPI PIO
 PIO spi_pio;
@@ -912,11 +913,15 @@ void dmd_dma_handler() {
          loopback ? source_bytes : target_bytes);
 
   dmd_prepare_dma_sniffer();
+  switch_buffers();
+
+  if (!filled_buffer) {
+    filled_buffer = true;
+    return;
+  }
 
   frame_crc = dma_hw->sniff_data;
   dma_hw->sniff_data = 0xFFFFFFFF;  // always clean after sniffing!
-
-  switch_buffers();
 
   if (frame_crc != crc_previous_frame) {
     crc_previous_frame = frame_crc;

--- a/src/dmdreader.cpp
+++ b/src/dmdreader.cpp
@@ -913,15 +913,16 @@ void dmd_dma_handler() {
          loopback ? source_bytes : target_bytes);
 
   dmd_prepare_dma_sniffer();
+  frame_crc = dma_hw->sniff_data;
+  dma_hw->sniff_data = 0xFFFFFFFF;  // always clean after sniffing!
+
   switch_buffers();
 
+  // first buffer sent is empty, so allow it to fill up first.
   if (!filled_buffer) {
     filled_buffer = true;
     return;
   }
-
-  frame_crc = dma_hw->sniff_data;
-  dma_hw->sniff_data = 0xFFFFFFFF;  // always clean after sniffing!
 
   if (frame_crc != crc_previous_frame) {
     crc_previous_frame = frame_crc;


### PR DESCRIPTION
Fixes the buffer not containing anything, but still sending. 
Now the very first frame that is sent immediately contains data.