### PR TITLE
Improve WPC RDATA autodetect

### DIFF
--- a/src/dmdreader.cpp
+++ b/src/dmdreader.cpp
@@ -348,7 +348,7 @@ DmdType detect_dmd() {
              (rclk < 2050) && (rdata > 55) && (rdata < 65)) {
     return DMD_SAM;
 
-    // WPC: DOTCLK: 500000 | RCLK: 3900 | RDATA: 120
+    // WPC: DOTCLK: 500000 | RCLK: 3900 | RDATA: 120 (doubled in some cases)
   } else if ((dotclk > 450000) && (dotclk < 550000) && (rclk > 3800) &&
              (rclk < 4000) && (rdata > 115) && (rdata < 260)) {
     return DMD_WPC;

--- a/src/dmdreader.cpp
+++ b/src/dmdreader.cpp
@@ -350,7 +350,7 @@ DmdType detect_dmd() {
 
     // WPC: DOTCLK: 500000 | RCLK: 3900 | RDATA: 120
   } else if ((dotclk > 450000) && (dotclk < 550000) && (rclk > 3800) &&
-             (rclk < 4000) && (rdata > 115) && (rdata < 130)) {
+             (rclk < 4000) && (rdata > 115) && (rdata < 260)) {
     return DMD_WPC;
 
     // DOTMATION: DOTCLK: 1900000 | RCLK: 9950 | RDATA: 155


### PR DESCRIPTION
- In some interesting cases on WPC games the RDATA rate is doubled. This does not affect the reader, the frames still display fine. Though the autodetection value needs to be increased.